### PR TITLE
feat: set the CWD for pandoc to the input dir

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -119,7 +119,8 @@ export default class PandocPlugin extends Plugin {
                         const result = await pandoc(
                             {
                                 file: 'STDIN', contents: html, format: 'html', metadataFile,
-                                pandoc: this.settings.pandoc, pdflatex: this.settings.pdflatex
+                                pandoc: this.settings.pandoc, pdflatex: this.settings.pdflatex,
+				directory: path.dirname(inputFile)
                             },
                             { file: outputFile, format },
                             this.settings.extraArguments.split('\n')
@@ -133,7 +134,8 @@ export default class PandocPlugin extends Plugin {
                     const result = await pandoc(
                         {
                             file: inputFile, format: 'markdown',
-                            pandoc: this.settings.pandoc, pdflatex: this.settings.pdflatex
+                            pandoc: this.settings.pandoc, pdflatex: this.settings.pdflatex,
+			    directory: path.dirname(inputFile)
                         },
                         { file: outputFile, format },
                         this.settings.extraArguments.split('\n')

--- a/pandoc.ts
+++ b/pandoc.ts
@@ -64,6 +64,7 @@ export interface PandocInput {
     metadataFile?: string,  // path to YAML file
     pandoc?: string, // optional path to Pandoc if it's not in the current PATH variable
     pdflatex?: string, // ditto for pdflatex
+    directory: AbsoluteFilePath, // The directory the source file resides in
 }
 
 export interface PandocOutput {
@@ -158,7 +159,7 @@ export const pandoc = async (input: PandocInput, output: PandocOutput, extraPara
                 env.PATH += ":";
             env.PATH += path.dirname(input.pdflatex);
         }
-        pandoc = spawn(input.pandoc || 'pandoc', args, { env: process.env });
+        pandoc = spawn(input.pandoc || 'pandoc', args, { env: process.env, cwd: input.directory });
 
         if (stdin) {
             // TODO: strip some unicode characters but not others


### PR DESCRIPTION
This sets the working directory of pandoc to teh directory the source
file lives in. This makes it easier to use resources located relative to
the input file.

An example is a logo reference in a frontmatter block for a pandoc
template (like the eisvogel template).